### PR TITLE
correct TAREA stored in dso in grid.get_grid

### DIFF
--- a/pop_tools/grid.py
+++ b/pop_tools/grid.py
@@ -125,7 +125,7 @@ def get_grid(grid_name, scrip=False):
     )
 
     dso['TAREA'] = xr.DataArray(
-        TAREA / deg2rad,
+        TAREA,
         dims=('nlat', 'nlon'),
         attrs={'units': 'cm^2', 'long_name': 'area of T cells', 'coordinates': 'TLONG TLAT'},
     )


### PR DESCRIPTION
TAREA was incorrectly being divided by deg2rad when stored in dso