### PR TITLE
Print out available grids to user on get_grid()

### DIFF
--- a/pop_tools/grid.py
+++ b/pop_tools/grid.py
@@ -25,7 +25,10 @@ def get_grid(grid_name, scrip=False):
     """
 
     if grid_name not in grid_defs:
-        raise ValueError(f'Unknown grid: {grid_name}')
+        raise ValueError(
+            f"""Unknown grid: {grid_name}
+             Please select from the following: {list(grid_defs.keys())}"""
+        )
 
     grid_attrs = grid_defs[grid_name]
 


### PR DESCRIPTION
Simple fix for better error-reporting. I had to go to the repo and check the grid yaml file to see what was available. This adds the following error message to make things more clear for someone less experienced with POP grids.

```python
from pop_tools.grid import get_grid
get_grid('none')
```

<img width="741" alt="Screen Shot 2019-05-29 at 10 40 30 AM" src="https://user-images.githubusercontent.com/8881170/58575175-cba86d80-81fe-11e9-832b-d1d1f91ba71f.png">
