### PR TITLE
enable coeff computation with dask

### DIFF
--- a/pop_tools/eos.py
+++ b/pop_tools/eos.py
@@ -100,10 +100,6 @@ def eos(salt, temp, return_coefs=False, **kwargs):
         salt, temp, pressure = xr.broadcast(salt, temp, pressure)
 
         if return_coefs:
-
-            # RHO = xr.full_like(salt, fill_value=np.nan)
-            # dRHOdS = xr.full_like(salt, fill_value=np.nan)
-            # dRHOdT = xr.full_like(salt, fill_value=np.nan)
             RHO, dRHOdS, dRHOdT = _compute_eos_coeffs(salt, temp, pressure)
 
             dRHOdS.name = 'dRHOdS'

--- a/pop_tools/eos.py
+++ b/pop_tools/eos.py
@@ -101,16 +101,10 @@ def eos(salt, temp, return_coefs=False, **kwargs):
 
         if return_coefs:
 
-            if isinstance(salt.data, dask.array.Array):
-                raise NotImplementedError('cannot return coefficient with dask')
-
-            else:
-                RHO = xr.full_like(salt, fill_value=np.nan)
-                dRHOdS = xr.full_like(salt, fill_value=np.nan)
-                dRHOdT = xr.full_like(salt, fill_value=np.nan)
-                RHO[:], dRHOdS[:], dRHOdT[:] = _compute_eos_coeffs(
-                    salt.data, temp.data, pressure.data
-                )
+            # RHO = xr.full_like(salt, fill_value=np.nan)
+            # dRHOdS = xr.full_like(salt, fill_value=np.nan)
+            # dRHOdT = xr.full_like(salt, fill_value=np.nan)
+            RHO, dRHOdS, dRHOdT = _compute_eos_coeffs(salt, temp, pressure)
 
             dRHOdS.name = 'dRHOdS'
             dRHOdS.attrs['units'] = 'kg/m^3/degC'
@@ -233,7 +227,7 @@ def _compute_eos(salt, temp, pressure):
     return WORK1 * DENOMK
 
 
-@jit(nopython=True)
+# @jit(nopython=True)
 def _compute_eos_coeffs(salt, temp, pressure):
     # MWJF EOS coefficients
     # *** these constants will be used to construct the numerator

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -37,6 +37,8 @@ def test_eos_xarray_2():
     )
     rho, drhodS, drhodT = pop_tools.eos(ds.SALT, ds.TEMP, depth=ds.z_t * 1e-2, return_coefs=True)
     assert isinstance(rho, xr.DataArray)
+    assert isinstance(drhodS, xr.DataArray)
+    assert isinstance(drhodT, xr.DataArray)
 
 
 def test_eos_ds_dask():
@@ -48,3 +50,16 @@ def test_eos_ds_dask():
     )
     rho = pop_tools.eos(ds.SALT, ds.TEMP, depth=ds.z_t * 1e-2)
     assert isinstance(rho, xr.DataArray)
+
+
+def test_eos_ds_dask_2():
+    ds = xr.open_dataset(
+        f'{testdata_dir}/cesm_pop_monthly.T62_g17.nc',
+        decode_times=False,
+        decode_coords=False,
+        chunks={'z_t': 20},
+    )
+    rho, drhodS, drhodT = pop_tools.eos(ds.SALT, ds.TEMP, depth=ds.z_t * 1e-2, return_coefs=True)
+    assert isinstance(rho, xr.DataArray)
+    assert isinstance(drhodS, xr.DataArray)
+    assert isinstance(drhodT, xr.DataArray)


### PR DESCRIPTION
This PR enables computation of the coefficients of EOS to proceed when dask is being used.

cc @sgyeager, @whokim 