### PR TITLE
Test against Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,13 @@ workflows:
       - "upstream-dev"
       - "python-3.6"
       - "python-3.7"
-      # - "python-3.8"
+      - "python-3.8"
   default:
     jobs:
       - "upstream-dev"
       - "python-3.6"
       - "python-3.7"
-      # - "python-3.8"
+      - "python-3.8"
 
 shared: &shared
   steps:
@@ -79,10 +79,9 @@ jobs:
     environment:
       ENV_FILE: "./ci/environment.yml"
 
-  # Waiting Waiting on Numba 0.47 release
-  # "python-3.8":
-  #   <<: *shared
-  #   docker:
-  #     - image: ncarxdev/miniconda:3.8
-  #   environment:
-  #     ENV_FILE: "./ci/environment.yml"
+  "python-3.8":
+    <<: *shared
+    docker:
+      - image: ncarxdev/miniconda:3.8
+    environment:
+      ENV_FILE: "./ci/environment.yml"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,6 +3,8 @@ name: code-style
 on:
   push:
     branches: "*"
+  pull_request:
+    branches: master
 
 jobs:
 

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -1,6 +1,7 @@
 name: pop-tools-dev
 channels:
   - conda-forge
+  - numba
 dependencies:
   - bottleneck
   - codecov

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,6 +1,7 @@
 name: pop-tools-dev
 channels:
   - conda-forge
+  - numba
 dependencies:
   - bottleneck
   - codecov


### PR DESCRIPTION
Numba 0.47.0 was released a few days ago. It adds Python 3.8 support. Numba 0.47.0 is not available on conda-forge channel yet (which is why this PR adds the numba channel to the environment YAML file). 