### PR TITLE
include DXU, DYU, UAREA; update DXT[0,:] to assumed-periodic

### DIFF
--- a/pop_tools/grid.py
+++ b/pop_tools/grid.py
@@ -92,7 +92,7 @@ def get_grid(grid_name, scrip=False):
     DXT = np.empty((nlat, nlon))
     DXT[1:, :] = 0.5 * (HTN[: nlat - 1, :] + HTN[1:, :])
     # DXT[0, :] = 0.5 * (2 * HTN[0, :] - HTN[1, :] + HTN[0, :])
-    DXT[0, :] = 0.5 * (HTN[0, :] + HTN[-1, :])
+    DXT[0, :] = 0.5 * (HTN[0, :] + HTN[nlat - 1, :])
 
     # DYT[i,j] = (HTE[i,j] + HTE[i−1,j])/2
     DYT = np.empty((nlat, nlon))


### PR DESCRIPTION
This produces output on the gx1v7 grid that is consistent with model-written data. I ran `ds_compare` to compare `pop_tools` output with grid variables from a CMIP6 run. This is the result of the values comparison:
```
TLAT: close
TLONG: close
ULAT: identical
ULONG: identical
DXT: identical
DYT: identical
DXU: identical
DYU: identical
TAREA: identical
UAREA: identical
KMT: different
```
`TLAT` and `TLONG` are computed in `pop_tools` from `ULAT` and `ULONG`, so therefore subject to numerical precision issues.

We read `KMT` from a topography file; I think it is different because of the overflow parameterization, which pops KMT down at runtime. Here's plot of the `pop_tools.get_grid('gx1v7).KMT - ds_ref.KMT`:
![image](https://user-images.githubusercontent.com/9341267/76107705-79b72400-5f96-11ea-99ae-da32ea7751a1.png)

Indeed, the overflows are the problem. I will file an issue ticket about this. We should also add a regression test for complete grid variable converge (currently we are only testing a subset).