### PR TITLE
drop old coordinates 'nlat' 'nlon' if present, rename z_w to z_w_top …

### DIFF
--- a/pop_tools/xgcm_util.py
+++ b/pop_tools/xgcm_util.py
@@ -102,7 +102,7 @@ def relabel_pop_dims(ds):
     for coord in old_coords:
         if coord in ds_new.coords:
             ds_new = ds_new.drop_vars(coord)
-    if 'z_w_top' and 'z_w' in ds_new.dims:
+    if 'z_w_top' in ds_new.dims and 'z_w' in ds_new.dims:
         ds_new = ds_new.drop('z_w_top').rename({'z_w': 'z_w_top'})
     return ds_new
 

--- a/pop_tools/xgcm_util.py
+++ b/pop_tools/xgcm_util.py
@@ -201,5 +201,11 @@ def to_xgcm_grid_dataset(ds, **kwargs):
             """to_xgcm_grid_dataset() function requires the `xgcm` package. \nYou can install it via PyPI or Conda"""
         )
     ds_new = relabel_pop_dims(ds)
+    if 'nlat' in ds_new.dims:
+        ds_new = ds_new.drop('nlat')
+    if 'nlon' in ds_new.dims:
+        ds_new = ds_new.drop('nlon')
+    if 'z_w_top' and 'z_w' in ds_new.dims:
+        ds_new = ds_new.drop('z_w_top').rename({'z_w': 'z_w_top'}) 
     grid = xgcm.Grid(ds_new, **kwargs)
     return grid, ds_new

--- a/pop_tools/xgcm_util.py
+++ b/pop_tools/xgcm_util.py
@@ -102,7 +102,6 @@ def relabel_pop_dims(ds):
     for coord in old_coords:
         if coord in ds_new.coords:
             ds_new = ds_new.drop_vars(coord)
-        assert coord not in ds_new.dims
     if 'z_w_top' and 'z_w' in ds_new.dims:
         ds_new = ds_new.drop('z_w_top').rename({'z_w': 'z_w_top'})
     return ds_new

--- a/pop_tools/xgcm_util.py
+++ b/pop_tools/xgcm_util.py
@@ -98,6 +98,12 @@ def relabel_pop_dims(ds):
             else:
                 dims = new_spatial_dims
             ds_new[vname] = xr.Variable(dims, da.data, da.attrs, da.encoding, fastpath=True)
+    if 'nlat' in ds_new.dims:
+        ds_new = ds_new.drop('nlat')
+    if 'nlon' in ds_new.dims:
+        ds_new = ds_new.drop('nlon')
+    if 'z_w_top' and 'z_w' in ds_new.dims:
+        ds_new = ds_new.drop('z_w_top').rename({'z_w': 'z_w_top'})
     return ds_new
 
 
@@ -201,11 +207,5 @@ def to_xgcm_grid_dataset(ds, **kwargs):
             """to_xgcm_grid_dataset() function requires the `xgcm` package. \nYou can install it via PyPI or Conda"""
         )
     ds_new = relabel_pop_dims(ds)
-    if 'nlat' in ds_new.dims:
-        ds_new = ds_new.drop('nlat')
-    if 'nlon' in ds_new.dims:
-        ds_new = ds_new.drop('nlon')
-    if 'z_w_top' and 'z_w' in ds_new.dims:
-        ds_new = ds_new.drop('z_w_top').rename({'z_w': 'z_w_top'}) 
     grid = xgcm.Grid(ds_new, **kwargs)
     return grid, ds_new

--- a/pop_tools/xgcm_util.py
+++ b/pop_tools/xgcm_util.py
@@ -98,10 +98,11 @@ def relabel_pop_dims(ds):
             else:
                 dims = new_spatial_dims
             ds_new[vname] = xr.Variable(dims, da.data, da.attrs, da.encoding, fastpath=True)
-    if 'nlat' in ds_new.dims:
-        ds_new = ds_new.drop('nlat')
-    if 'nlon' in ds_new.dims:
-        ds_new = ds_new.drop('nlon')
+    old_coords = ['nlat', 'nlon']
+    for coord in old_coords:
+        if coord in ds_new.coords:
+            ds_new = ds_new.drop_vars(coord)
+        assert coord not in ds_new.dims
     if 'z_w_top' and 'z_w' in ds_new.dims:
         ds_new = ds_new.drop('z_w_top').rename({'z_w': 'z_w_top'})
     return ds_new

--- a/tests/test_xgcm_util.py
+++ b/tests/test_xgcm_util.py
@@ -17,7 +17,7 @@ def test_to_xgcm_grid_dataset(file):
     grid, ds_new = pop_tools.to_xgcm_grid_dataset(ds, metrics=None)
     assert isinstance(grid, xgcm.Grid)
     assert set(['X', 'Y', 'Z']) == set(grid.axes.keys())
-    new_spatial_coords = set(['nlon_u', 'nlat_u', 'nlon_t', 'nlat_t'])
+    new_spatial_coords = ['nlon_u', 'nlat_u', 'nlon_t', 'nlat_t']
     for coord in new_spatial_coords:
         assert coord in ds_new.coords
         assert coord not in ds.coords

--- a/tests/test_xgcm_util.py
+++ b/tests/test_xgcm_util.py
@@ -21,7 +21,7 @@ def test_to_xgcm_grid_dataset(file):
     for coord in new_spatial_coords:
         assert coord in ds_new.coords
         assert coord not in ds.coords
-    old_spatial_coords = set(['nlat', 'nlon', 'z_w'])
+    old_spatial_coords = ['nlat', 'nlon', 'z_w']
     for coord in old_spatial_coords:
         assert coord not in ds_new.coords
 

--- a/tests/test_xgcm_util.py
+++ b/tests/test_xgcm_util.py
@@ -21,6 +21,9 @@ def test_to_xgcm_grid_dataset(file):
     for coord in new_spatial_coords:
         assert coord in ds_new.coords
         assert coord not in ds.coords
+    old_spatial_coords = set(['nlat', 'nlon', 'z_w'])
+    for coord in old_spatial_coords:
+        assert coord not in ds_new.coords
 
 
 def test_to_xgcm_grid_dataset_missing_xgcm():


### PR DESCRIPTION
…if both present

'nlat' and 'nlon' are old coordinates and should not be included in the new ds.
if 'z_w_top' and 'z_w' are both present, drop 'z_w' and rename to 'z_w_top', to facilitate, e.g., multiplication with variables on those levels (the depths of 'z_w' and 'z_w_top' are identical