### PR TITLE
Add HU, HT, KMU to get grid

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 import xarray as xr
 
 import pop_tools
@@ -26,3 +27,12 @@ def test_get_grid_scrip():
     ds_test = pop_tools.get_grid('POP_gx3v7', scrip=True)
     ds_ref = xr.open_dataset(DATASETS.fetch('POP_gx3v7.nc'))
     assert ds_compare(ds_test, ds_ref, assertion='allclose', rtol=1e-14, atol=1e-14)
+
+
+@pytest.mark.parametrize('grid', pop_tools.grid_defs.keys())
+def test_HT_HU_KMU_in_grid(grid):
+    print(grid)
+    ds = pop_tools.get_grid(grid)
+    assert 'HT' in ds, 'Missing variable HT'
+    assert 'HU' in ds, 'Missing variable HU'
+    assert 'KMU' in ds, 'Missing variable KMU'


### PR DESCRIPTION
This PR derives and adds `HU`, `HT`, and `KMU` as default output for the `get_grid` function. It follows @matt-long's equations in #14, per the POP reference manual (3.2 and 3.3).

Closes #14.
