### PR TITLE
Change where() statements to clip()

### DIFF
--- a/pop_tools/eos.py
+++ b/pop_tools/eos.py
@@ -94,10 +94,9 @@ def eos(salt, temp, return_coefs=False, **kwargs):
     smax = 999.0
 
     if use_xarray:
-        temp = xr.where(temp < tmin, tmin, temp)
-        temp = xr.where(temp > tmax, tmax, temp)
-        salt = xr.where(salt < smin, smin, salt)
-        salt = xr.where(salt > smax, smax, salt)
+
+        temp = temp.clip(tmin, tmax)
+        salt = salt.clip(smin, smax)
 
         salt, temp, pressure = xr.broadcast(salt, temp, pressure)
         if isinstance(salt.data, dask.array.Array):
@@ -133,10 +132,9 @@ def eos(salt, temp, return_coefs=False, **kwargs):
         RHO.attrs['long_name'] = 'Density'
 
     else:
-        temp = np.where(temp < tmin, tmin, temp)
-        temp = np.where(temp > tmax, tmax, temp)
-        salt = np.where(salt < smin, smin, salt)
-        salt = np.where(salt > smax, smax, salt)
+
+        temp = np.clip(temp, tmin, tmax)
+        salt = np.clip(salt, smin, smax)
 
         if return_coefs:
             RHO, dRHOdS, dRHOdT = _compute_eos_coeffs(salt, temp, pressure)

--- a/pop_tools/eos.py
+++ b/pop_tools/eos.py
@@ -94,7 +94,6 @@ def eos(salt, temp, return_coefs=False, **kwargs):
     smax = 999.0
 
     if use_xarray:
-
         temp = temp.clip(tmin, tmax)
         salt = salt.clip(smin, smax)
 
@@ -132,7 +131,6 @@ def eos(salt, temp, return_coefs=False, **kwargs):
         RHO.attrs['long_name'] = 'Density'
 
     else:
-
         temp = np.clip(temp, tmin, tmax)
         salt = np.clip(salt, smin, smax)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 xarray>=0.15.0
 dask>=2.10
 pooch>=0.7.0
+numpy>=1.17.0


### PR DESCRIPTION
Fixes #60 

I was hoping to be able to put

```
temp = temp.clip(tmin, tmax)
salt = salt.clip(smin, smax)
```

outside the if statement, but ran into

```
==================================================== short test summary info =====================================================
FAILED tests/test_eos.py::test_eos_numpy_1 - AttributeError: 'float' object has no attribute 'clip'
FAILED tests/test_eos.py::test_eos_numpy_2 - AttributeError: 'float' object has no attribute 'clip'
FAILED tests/test_eos.py::test_eos_numpy_3 - AttributeError: 'float' object has no attribute 'clip'

```

in testing