### PR TITLE
Fix get_grid when region_mask_regions data is present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# VSCode
+.vscode

--- a/pop_tools/grid.py
+++ b/pop_tools/grid.py
@@ -316,16 +316,16 @@ def get_grid(grid_name, scrip=False):
 
     grid_attrs.update({'title': f'{grid_name} grid'})
 
+    dso.attrs = grid_attrs
+
     # Remove region_mask_regions
-    if 'region_mask_regions' in grid_attrs:
-        regions = grid_attrs.pop('region_mask_regions')
+    if 'region_mask_regions' in dso.attrs:
+        regions = dso.attrs.pop('region_mask_regions')
         region_names, region_vals = list(zip(*regions.items()))
         region_coord = list(range(len(regions)))
         dso['region_name'] = xr.DataArray(list(region_names), coords=[region_coord], dims=['nreg'])
         dso['region_val'] = xr.DataArray(list(region_vals), coords=[region_coord], dims=['nreg'])
         dso['region_val'].attrs['coordinate'] = 'region_name'
-
-    dso.attrs = grid_attrs
 
     return dso
 

--- a/pop_tools/grid.py
+++ b/pop_tools/grid.py
@@ -315,6 +315,30 @@ def get_grid(grid_name, scrip=False):
         )
 
     grid_attrs.update({'title': f'{grid_name} grid'})
+
+    # Remove region_mask_regions
+    if 'region_mask_regions' in grid_attrs:
+        regions = grid_attrs.pop('region_mask_regions')
+        '''
+        Sample contents of regions:
+        {
+            'Caspian Sea': -14,
+            'Black Sea': -13,
+            'Baltic Sea': -12,
+            'Red Sea': -5,
+            'Southern Ocean': 1,
+            'Pacific Ocean': 2,
+            'Indian Ocean': 3,
+            'Persian Gulf': 4,
+            'Atlantic Ocean': 6,
+            'Mediterranean Sea': 7,
+            'Lab. Sea & Baffin Bay': 8,
+            'GIN Seas': 9,
+            'Arctic Ocean': 10,
+            'Hudson Bay': 11
+        }
+        '''
+        # TODO: turn the regions dictionary into two lists
     dso.attrs = grid_attrs
 
     return dso

--- a/pop_tools/grid.py
+++ b/pop_tools/grid.py
@@ -319,14 +319,11 @@ def get_grid(grid_name, scrip=False):
     # Remove region_mask_regions
     if 'region_mask_regions' in grid_attrs:
         regions = grid_attrs.pop('region_mask_regions')
-        region_names = list(regions.keys())
-        region_vals = list(regions.values())
-        nregions = len(regions)
-        region_coord = list(range(nregions))
-        da_region_names = xr.DataArray(region_names, coords=[region_coord], dims=['nregions'])
-        da_region_vals = xr.DataArray(region_vals, coords=[region_coord], dims=['nregions'])
-        dso['region_name'] = da_region_names
-        dso['region_val'] = da_region_vals
+        region_names, region_vals = list(zip(*regions.items()))
+        region_coord = list(range(len(regions)))
+        dso['region_name'] = xr.DataArray(list(region_names), coords=[region_coord], dims=['nreg'])
+        dso['region_val'] = xr.DataArray(list(region_vals), coords=[region_coord], dims=['nreg'])
+        dso['region_val'].attrs['coordinate'] = 'region_name'
 
     dso.attrs = grid_attrs
 

--- a/pop_tools/grid.py
+++ b/pop_tools/grid.py
@@ -319,26 +319,15 @@ def get_grid(grid_name, scrip=False):
     # Remove region_mask_regions
     if 'region_mask_regions' in grid_attrs:
         regions = grid_attrs.pop('region_mask_regions')
-        '''
-        Sample contents of regions:
-        {
-            'Caspian Sea': -14,
-            'Black Sea': -13,
-            'Baltic Sea': -12,
-            'Red Sea': -5,
-            'Southern Ocean': 1,
-            'Pacific Ocean': 2,
-            'Indian Ocean': 3,
-            'Persian Gulf': 4,
-            'Atlantic Ocean': 6,
-            'Mediterranean Sea': 7,
-            'Lab. Sea & Baffin Bay': 8,
-            'GIN Seas': 9,
-            'Arctic Ocean': 10,
-            'Hudson Bay': 11
-        }
-        '''
-        # TODO: turn the regions dictionary into two lists
+        region_names = list(regions.keys())
+        region_vals = list(regions.values())
+        nregions = len(regions)
+        region_coord = list(range(nregions))
+        da_region_names = xr.DataArray(region_names, coords=[region_coord], dims=['nregions'])
+        da_region_vals = xr.DataArray(region_vals, coords=[region_coord], dims=['nregions'])
+        dso['region_name'] = da_region_names
+        dso['region_val'] = da_region_vals
+
     dso.attrs = grid_attrs
 
     return dso

--- a/pop_tools/region_masks.py
+++ b/pop_tools/region_masks.py
@@ -57,7 +57,7 @@ def region_mask_3d(grid_name, mask_name=None, region_defs=None):
         mask_name = 'user-defined'
 
     if region_defs is None:
-        region_defs = _get_region_defititions(ds, grid_name, mask_name)
+        region_defs = _get_region_definitions(ds, grid_name, mask_name)
 
     _verify_region_def_schema(region_defs)
 
@@ -131,7 +131,7 @@ def _verify_region_def_schema(region_defs):
                 assert crit_type in ['bounds', 'match']
 
 
-def _get_region_defititions(ds, grid_name, mask_name):
+def _get_region_definitions(ds, grid_name, mask_name):
     """Return the region mask definition from `region_mask_definitions.yaml`."""
     if mask_name == 'default':
         grid_attrs = grid_defs[grid_name]

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -27,11 +27,13 @@ def test_get_grid_scrip():
     ds_ref = xr.open_dataset(DATASETS.fetch('POP_gx3v7.nc'))
     assert ds_compare(ds_test, ds_ref, assertion='allclose', rtol=1e-14, atol=1e-14)
 
+
 def test_get_grid_to_netcdf():
     for grid in pop_tools.grid_defs.keys():
         print('-' * 80)
         print(grid)
         ds = pop_tools.get_grid(grid)
-        gridfile = f'{grid}.nc'
-        ds.to_netcdf(gridfile)
-        os.system(f'rm -f {gridfile}')
+        for format in ['NETCDF4', 'NETCDF3_64BIT']:
+            gridfile = f'{grid}_{format}.nc'
+            ds.to_netcdf(gridfile)
+            os.system(f'rm -f {gridfile}')

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -35,5 +35,5 @@ def test_get_grid_to_netcdf():
         ds = pop_tools.get_grid(grid)
         for format in ['NETCDF4', 'NETCDF3_64BIT']:
             gridfile = f'{grid}_{format}.nc'
-            ds.to_netcdf(gridfile)
+            ds.to_netcdf(gridfile, format=format)
             os.system(f'rm -f {gridfile}')

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -26,3 +26,12 @@ def test_get_grid_scrip():
     ds_test = pop_tools.get_grid('POP_gx3v7', scrip=True)
     ds_ref = xr.open_dataset(DATASETS.fetch('POP_gx3v7.nc'))
     assert ds_compare(ds_test, ds_ref, assertion='allclose', rtol=1e-14, atol=1e-14)
+
+def test_get_grid_to_netcdf():
+    for grid in pop_tools.grid_defs.keys():
+        print('-' * 80)
+        print(grid)
+        ds = pop_tools.get_grid(grid)
+        gridfile = f'{grid}.nc'
+        ds.to_netcdf(gridfile)
+        os.system(f'rm -f {gridfile}')

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -28,6 +28,12 @@ def test_get_grid_scrip():
     assert ds_compare(ds_test, ds_ref, assertion='allclose', rtol=1e-14, atol=1e-14)
 
 
+def test_get_grid_twice():
+    ds1 = pop_tools.get_grid('POP_gx1v7')
+    ds2 = pop_tools.get_grid('POP_gx1v7')
+    xr.testing.assert_identical(ds1, ds2)
+
+
 def test_get_grid_to_netcdf():
     for grid in pop_tools.grid_defs.keys():
         print('-' * 80)


### PR DESCRIPTION
I've implemented a simple fix for the `pop_tools.get_grid` error described in #45, and I've included a test.  This solution was developed mostly under the guidance of @mnlevy1981, but my solution differs from the solution proposed by @klindsay28 in the discussions under #45.  

I opted for a `string` datatype in the NetCDF file, rather than the `char`  datatype.  This appears to work for both `NETCDF4` and `NETCDF3_64BIT` NetCDF file formats, which is surprising to me!  The advantage of the `string` datatype is that you do not need the `nchar` dimension to indicate maximum length of the strings.  However, documentation on NetCDF seems to suggest that `string` types are only supported by NetCDF4 and not the more general CDF5.

Since this PR appears to work (so far), I might suggest that either the resulting NetCDF grid files be tested by other people now or we accept this PR *for now* and work on a simple fix if it is discovered to be a problem in the future.

The new data added to the NetCDF grid files is summarized below:

```text
dimensions:
        nreg = 14 ;
variables:
        int64 nreg(nreg) ;
        string region_name(nreg) ;
        int64 region_val(nreg) ;
                region_val:coordinate = "region_name" ;
```