### PR TITLE
Use vectorize instead of jit in EOS

### DIFF
--- a/pop_tools/eos.py
+++ b/pop_tools/eos.py
@@ -113,18 +113,14 @@ def eos(salt, temp, return_coefs=False, **kwargs):
             dRHOdT.attrs['long_name'] = 'Thermal expansion coefficient'
 
         else:
-            if isinstance(salt.data, dask.array.Array):
-                RHO = xr.apply_ufunc(
-                    _compute_eos,
-                    salt,
-                    temp,
-                    pressure,
-                    dask='parallelized',
-                    output_dtypes=[salt.dtype],
-                )
-            else:
-                RHO = xr.full_like(salt, fill_value=np.nan)
-                RHO[:] = _compute_eos(salt.data, temp.data, pressure.data)
+            RHO = xr.apply_ufunc(
+                _compute_eos,
+                salt,
+                temp,
+                pressure,
+                dask='parallelized',
+                output_dtypes=[salt.dtype],
+            )
 
         RHO.name = 'density'
         RHO.attrs['units'] = 'kg/m^3'

--- a/pop_tools/eos.py
+++ b/pop_tools/eos.py
@@ -1,10 +1,10 @@
 import dask
 import numpy as np
 import xarray as xr
-from numba import jit
+from numba import vectorize
 
 
-@jit(nopython=True)
+@vectorize(['float64(float64)', 'float32(float32)'], nopython=True)
 def compute_pressure(depth):
     """
     Convert depth in meters to pressure in bars.
@@ -145,7 +145,10 @@ def eos(salt, temp, return_coefs=False, **kwargs):
         return RHO
 
 
-@jit(nopython=True)
+@vectorize(
+    ['float64(float64, float64, float64)', 'float32(float32, float32, float32)'],
+    nopython=True,
+)
 def _compute_eos(salt, temp, pressure):
     # MWJF EOS coefficients
     # *** these constants will be used to construct the numerator


### PR DESCRIPTION
This PR replaces the use of the `@jit` numba decorator with the `@vectorize` decorator in the eos calculation. According to the [numba docs](https://numba.pydata.org/numba-doc/latest/user/vectorize.html), `@vectorize` is the recommended way to create a numpy ufunc, which I believe is what is wanted here.

The speedup on my laptop is about 3x:
```python
import numpy as np
from pop_tools import eos

N = 10_000_000
salt = 30 + 10 * np.random.random_sample(N)
theta = -2 + 30 * np.random.random_sample(N)
pres = 5000 * np.random.random_sample(N)

%timeit eos(salt, theta, pressure=pres)
# master -> 326 ms ± 2.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# this PR -> 92.2 ms ± 855 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
I also removed what seems to be an unnecessary if clause regarding `xarray.apply_ufunc`.

