### PR TITLE
⬆️  Upgrade dependencies and pin minimum versions

### DIFF
--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -6,11 +6,11 @@ dependencies:
   - codecov
   - docrep=0.2.7
   - netcdf4
-  - numba
+  - numba>=0.52
   - pip
-  - pooch
+  - pooch>=1.3.0
   - pytest-cov
-  - pyyaml
+  - pyyaml>=5.3.1
   - scipy
   - toolz
   - pip:

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -4,16 +4,16 @@ channels:
 dependencies:
   - bottleneck
   - codecov
-  - dask
-  - docrep=0.2.7
+  - dask>=2.14
+  - docrep==0.2.7
   - nbsphinx
   - netcdf4
-  - numba
+  - numba>=0.52
   - pip
-  - pooch
+  - pooch>=1.3.0
   - pytest-cov
-  - pyyaml
+  - pyyaml>=5.3.1
   - scipy
-  - xarray
+  - xarray>=0.16.1
   - xgcm
   - watermark

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numba>=0.48
-pyyaml
-xarray>=0.15.0
-dask>=2.10
-pooch>=0.7.0
+numba>=0.52
+pyyaml>=5.3.1
+xarray>=0.16.1
+dask>=2.14
+pooch>=1.3.0
 numpy>=1.17.0


### PR DESCRIPTION
Towards fixing most recent [CI failures](https://github.com/NCAR/pop-tools/actions/runs/422086284)