### PR TITLE
Extend to_xgcm_grid_dataset() to support POP datasets with non canonical dimensions

### DIFF
--- a/pop_tools/xgcm_util.py
+++ b/pop_tools/xgcm_util.py
@@ -93,10 +93,7 @@ def relabel_pop_dims(ds):
             da = ds_new[vname]
             dims_orig = da.dims
             new_spatial_dims = _dims_from_grid_loc(da.attrs['grid_loc'])
-            if dims_orig[0] == 'time':
-                dims = ('time',) + new_spatial_dims
-            else:
-                dims = new_spatial_dims
+            dims = dims_orig[: -len(new_spatial_dims)] + new_spatial_dims
             ds_new[vname] = xr.Variable(dims, da.data, da.attrs, da.encoding, fastpath=True)
     old_coords = ['nlat', 'nlon']
     for coord in old_coords:

--- a/tests/test_xgcm_util.py
+++ b/tests/test_xgcm_util.py
@@ -1,5 +1,6 @@
 import sys
 
+import numpy as np
 import pytest
 import xarray as xr
 import xgcm
@@ -7,23 +8,38 @@ import xgcm
 import pop_tools
 from pop_tools import DATASETS
 
+ds_a = xr.open_dataset(DATASETS.fetch('tend_zint_100m_Fe.nc'), chunks={})
+ds_b = xr.open_dataset(DATASETS.fetch('g.e20.G.TL319_t13.control.001_hfreq-coarsen.nc'), chunks={})
+ds_c = ds_a[['TLAT', 'ULONG', 'ULAT', 'TLONG']].isel(nlat=slice(0, 2), nlon=slice(0, 2))
+ds_c['anom'] = xr.DataArray(
+    np.arange(48).reshape(2, 2, 3, 2, 2),
+    dims=['S', 'L', 'M', 'nlat', 'nlon'],
+    coords={'S': [2000, 2001], 'L': [1, 2], 'M': [1, 2, 3]},
+    attrs={
+        'grid_loc': '2110',
+        'long_name': 'Dissolved Inorganic Iron Tendency Vertical Integral, 0-100m',
+        'cell_methods': 'time: mean',
+        'units': 'mmol/m^3 cm/s',
+    },
+)
+
 
 @pytest.mark.parametrize(
-    'file', ['tend_zint_100m_Fe.nc', 'g.e20.G.TL319_t13.control.001_hfreq-coarsen.nc']
+    'ds, old_spatial_coords, axes',
+    [
+        (ds_a, ['nlat', 'nlon', 'z_w'], ['X', 'Y', 'Z']),
+        (ds_b, ['nlat', 'nlon', 'z_w'], ['X', 'Y', 'Z']),
+        (ds_c, ['nlat', 'nlon'], ['X', 'Y']),
+    ],
 )
-def test_to_xgcm_grid_dataset(file):
-    filepath = DATASETS.fetch(file)
-    ds = xr.open_dataset(filepath)
+def test_to_xgcm_grid_dataset(ds, old_spatial_coords, axes):
     grid, ds_new = pop_tools.to_xgcm_grid_dataset(ds, metrics=None)
     assert isinstance(grid, xgcm.Grid)
-    assert set(['X', 'Y', 'Z']) == set(grid.axes.keys())
+    assert set(axes) == set(grid.axes.keys())
     new_spatial_coords = ['nlon_u', 'nlat_u', 'nlon_t', 'nlat_t']
-    for coord in new_spatial_coords:
-        assert coord in ds_new.coords
-        assert coord not in ds.coords
-    old_spatial_coords = ['nlat', 'nlon', 'z_w']
-    for coord in old_spatial_coords:
-        assert coord not in ds_new.coords
+    assert set(new_spatial_coords).issubset(set(ds_new.coords))
+    assert not set(new_spatial_coords).intersection(set(ds.coords))
+    assert not set(old_spatial_coords).intersection(set(ds_new.coords))
 
 
 def test_to_xgcm_grid_dataset_missing_xgcm():


### PR DESCRIPTION
- Fixes #93 
- Removes hard-coded time dim & support POP datasets with non canonical dimensions

