### PR TITLE
Mods to eos.py to improve dask compatibility

### DIFF
--- a/pop_tools/eos.py
+++ b/pop_tools/eos.py
@@ -81,11 +81,7 @@ def eos(salt, temp, return_coefs=False, **kwargs):
 
     # compute pressure
     if pressure is None:
-        if use_xarray:
-            pressure = xr.full_like(depth, fill_value=np.nan)
-            pressure[:] = 10.0 * compute_pressure(depth.data)  # dbar
-        else:
-            pressure = 10.0 * compute_pressure(depth)  # dbar
+	pressure = 10.0 * compute_pressure(depth)  # dbar
 
     # enforce min/max values
     tmin = -2.0
@@ -97,9 +93,7 @@ def eos(salt, temp, return_coefs=False, **kwargs):
         temp = temp.clip(tmin, tmax)
         salt = salt.clip(smin, smax)
 
-        salt, temp, pressure = xr.broadcast(salt, temp, pressure)
-        if isinstance(salt.data, dask.array.Array):
-            pressure = pressure.chunk(salt.chunks)
+	salt, temp = xr.broadcast(salt, temp)
 
         if return_coefs:
             RHO, dRHOdS, dRHOdT = _compute_eos_coeffs(salt, temp, pressure)

--- a/pop_tools/eos.py
+++ b/pop_tools/eos.py
@@ -81,7 +81,7 @@ def eos(salt, temp, return_coefs=False, **kwargs):
 
     # compute pressure
     if pressure is None:
-	pressure = 10.0 * compute_pressure(depth)  # dbar
+        pressure = 10.0 * compute_pressure(depth)  # dbar
 
     # enforce min/max values
     tmin = -2.0
@@ -92,8 +92,7 @@ def eos(salt, temp, return_coefs=False, **kwargs):
     if use_xarray:
         temp = temp.clip(tmin, tmax)
         salt = salt.clip(smin, smax)
-
-	salt, temp = xr.broadcast(salt, temp)
+        salt, temp = xr.broadcast(salt, temp)
 
         if return_coefs:
             RHO, dRHOdS, dRHOdT = _compute_eos_coeffs(salt, temp, pressure)

--- a/pop_tools/eos.py
+++ b/pop_tools/eos.py
@@ -75,8 +75,6 @@ def eos(salt, temp, return_coefs=False, **kwargs):
 
     use_xarray = False
     if any(isinstance(arg, xr.DataArray) for arg in [salt, temp, d_or_p]):
-        if not all(isinstance(arg, xr.DataArray) for arg in [salt, temp, d_or_p]):
-            raise ValueError('cannot operate on mixed types')
         use_xarray = True
 
     # compute pressure

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import pytest
 import xarray as xr
 
 import pop_tools
@@ -33,6 +34,16 @@ def test_eos_xarray_2():
     fname = DATASETS.fetch('cesm_pop_monthly.T62_g17.nc')
     ds = xr.open_dataset(fname, decode_times=False, decode_coords=False)
     rho, drhodS, drhodT = pop_tools.eos(ds.SALT, ds.TEMP, depth=ds.z_t * 1e-2, return_coefs=True)
+    assert isinstance(rho, xr.DataArray)
+    assert isinstance(drhodS, xr.DataArray)
+    assert isinstance(drhodT, xr.DataArray)
+
+
+@pytest.mark.parametrize('depth', (xr.DataArray([2000]), 2000.0))
+def test_eos_xarray_3(depth):
+    fname = DATASETS.fetch('cesm_pop_monthly.T62_g17.nc')
+    ds = xr.open_dataset(fname, decode_times=False, decode_coords=False)
+    rho, drhodS, drhodT = pop_tools.eos(ds.SALT, ds.TEMP, depth=depth, return_coefs=True)
     assert isinstance(rho, xr.DataArray)
     assert isinstance(drhodS, xr.DataArray)
     assert isinstance(drhodT, xr.DataArray)


### PR DESCRIPTION
The proposed mods allow depth to be passed to `eos()` as a simple 0-dimensional xarray DataArray, e.g.
`depth=xr.DataArray(2000)`
This is required if `salt` and `temp` args are DataArrays, but currently errors can arise if `depth` is 0-dimensional. Mods also improve performance if `salt` and `temp` are dask arrays by eliminating the unnecessary triple broadcasting of `salt`, `temp`, and `pressure`. The modified `eos()` works well for dask-enabled computation of MOC in sigma coordinates (https://github.com/sgyeager/POP_MOC). 
