### PR TITLE
Read The Docs configuration fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       - id: check-docstring-first
       - id: check-json
       - id: check-yaml
-      - id: double-quote-string-fixer
       - id: debug-statements
       - id: mixed-line-ending
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: blackdoc
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/isort

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,6 @@
 version: 2
+sphinx:
+  configuration: docs/source/conf.py
 conda:
   environment: docs/environment.yml
 build:


### PR DESCRIPTION
Addresses the deprecation described here by adding explicit configuration: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

And modifies the linter config and versions a bit to avoid the issues we were running into.