### PR TITLE
Update data access and Python versions in CI

### DIFF
--- a/.github/workflows/ci-upstream-dev.yaml
+++ b/.github/workflows/ci-upstream-dev.yaml
@@ -18,7 +18,7 @@ jobs:
           mamba-version: '*'
           activate-environment: pop-tools-dev
           auto-update-conda: false
-          python-version: 3.8
+          python-version: 3.12
           environment-file: ci/environment-upstream-dev.yml
       - name: Install pop-tools
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.12']
     steps:
       - uses: actions/checkout@v3
       - uses: conda-incubator/setup-miniconda@11ae174708d1ae769b9457e7d6ed64d606c99af1 #v2

--- a/pop_tools/datasets.py
+++ b/pop_tools/datasets.py
@@ -11,7 +11,7 @@ import pooch
 DATASETS = pooch.create(
     path=['~', '.pop_tools', 'data'],
     version_dev='master',
-    base_url='ftp://ftp.cgd.ucar.edu/archive/aletheia-data/cesm-data/ocn/',
+    base_url='https://ftp.cgd.ucar.edu/archive/aletheia-data/cesm-data/ocn/',
     env='POP_TOOLS_DATA_DIR',
 )
 DATASETS.load_registry(pkg_resources.resource_stream('pop_tools', 'data_registry.txt'))


### PR DESCRIPTION
Updates the data transfer protocol for accessing the test data to get CI working again and bumps the Python versions in CI.

If we don't bump the Python versions here, the tests will fail in the Python 3.8 environment with the particular combination of dependencies installed (because of the lack of a signature attribute on Numba DUFuncs).  Given that Python 3.8 is end-of-life and that the issue is resolved in more recent versions, I'm not inclined to spend more time diagnosing that.

Happy to split these changes (Python version bump and data transfer) up if that's preferred.  CI won't pass without both changes though.  

Closes #170