### PR TITLE
Update xgcm_util.relabel_pop_dims to fix Issue #97

### DIFF
--- a/pop_tools/xgcm_util.py
+++ b/pop_tools/xgcm_util.py
@@ -100,6 +100,7 @@ def relabel_pop_dims(ds):
         if coord in ds_new.coords:
             ds_new = ds_new.drop_vars(coord)
     if 'z_w_top' in ds_new.dims and 'z_w' in ds_new.dims:
+        ds_new['z_w'] = ds_new['z_w_top'].rename({'z_w_top': 'z_w'})
         ds_new = ds_new.drop_vars('z_w_top').rename({'z_w': 'z_w_top'})
     return ds_new
 


### PR DESCRIPTION
If the budget data does not include a `z_w` dimension, then `to_xgcm_grid_dataset()` does not make `z_w_top` a Z axis. This occurs when relabeling the POP dimensions and converting back and forth between `z_w` and `z_w_top`. This PR adds a line in `xgcm_util.relabel_pop_dims()` to explicitly define `z_w`.