### PR TITLE
Replace the use of now deprecated pkg_resources with importlib

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: black-jupyter
 
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.4.3
+    rev: v0.4.6
     hooks:
       - id: blackdoc
 

--- a/pop_tools/__init__.py
+++ b/pop_tools/__init__.py
@@ -1,6 +1,6 @@
 """Top-level module for pop_tools"""
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import version as _version
 
 from .calc import cfc11sol, cfc12sol
 from .datasets import DATASETS
@@ -11,7 +11,8 @@ from .region_masks import list_region_masks, region_mask_3d
 from .xgcm_util import to_xgcm_grid_dataset
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
-    pass
+    __version__ = _version("pop_tools")
+except Exception:
+    # Local copy or not installed with setuptools.
+    # Disable minimum version checks on downstream libraries.
+    __version__ = "9999"

--- a/pop_tools/datasets.py
+++ b/pop_tools/datasets.py
@@ -2,10 +2,10 @@
 Functions to load sample data
 """
 
+import importlib.resources
 import os
 from pathlib import Path
 
-import importlib.resources
 import pooch
 
 DATASETS = pooch.create(

--- a/pop_tools/datasets.py
+++ b/pop_tools/datasets.py
@@ -5,7 +5,7 @@ Functions to load sample data
 import os
 from pathlib import Path
 
-import pkg_resources
+import importlib.resources
 import pooch
 
 DATASETS = pooch.create(
@@ -14,7 +14,7 @@ DATASETS = pooch.create(
     base_url='https://ftp.cgd.ucar.edu/archive/aletheia-data/cesm-data/ocn/',
     env='POP_TOOLS_DATA_DIR',
 )
-DATASETS.load_registry(pkg_resources.resource_stream('pop_tools', 'data_registry.txt'))
+DATASETS.load_registry(importlib.resources.files('pop_tools').joinpath('data_registry.txt'))
 
 
 class UnzipZarr(pooch.processors.Unzip):

--- a/pop_tools/grid.py
+++ b/pop_tools/grid.py
@@ -1,7 +1,7 @@
+import importlib.resources
 import os
 from pathlib import Path
 
-import importlib.resources
 import numpy as np
 import pooch
 import xarray as xr

--- a/pop_tools/grid.py
+++ b/pop_tools/grid.py
@@ -1,8 +1,8 @@
 import os
 from pathlib import Path
 
+import importlib.resources
 import numpy as np
-import pkg_resources
 import pooch
 import xarray as xr
 import yaml
@@ -33,7 +33,7 @@ INPUTDATA = pooch.create(
 )
 
 
-INPUTDATA.load_registry(pkg_resources.resource_stream('pop_tools', 'inputdata_registry.txt'))
+INPUTDATA.load_registry(importlib.resources.files('pop_tools').joinpath('inputdata_registry.txt'))
 
 if tqdm is not None:
     downloader = pooch.HTTPDownloader(progressbar=True, verify=False, allow_redirects=True)
@@ -41,8 +41,8 @@ else:
     downloader = pooch.HTTPDownloader(verify=False, allow_redirects=True)
 
 
-grid_def_file = pkg_resources.resource_filename('pop_tools', 'pop_grid_definitions.yaml')
-input_templates_dir = pkg_resources.resource_filename('pop_tools', 'input_templates')
+grid_def_file = importlib.resources.files('pop_tools').joinpath('pop_grid_definitions.yaml')
+input_templates_dir = importlib.resources.files('pop_tools').joinpath('input_templates')
 
 with open(grid_def_file) as f:
     grid_defs = yaml.safe_load(f)

--- a/pop_tools/region_masks.py
+++ b/pop_tools/region_masks.py
@@ -1,11 +1,11 @@
 import numpy as np
-import pkg_resources
+import importlib.resources
 import xarray as xr
 import yaml
 
 from .grid import get_grid, grid_defs
 
-region_def_file = pkg_resources.resource_filename('pop_tools', 'region_mask_definitions.yaml')
+region_def_file = importlib.resources.files('pop_tools', 'region_mask_definitions.yaml')
 # open defined region masks
 with open(region_def_file) as f:
     all_region_defs = yaml.safe_load(f)

--- a/pop_tools/region_masks.py
+++ b/pop_tools/region_masks.py
@@ -1,5 +1,6 @@
-import numpy as np
 import importlib.resources
+
+import numpy as np
 import xarray as xr
 import yaml
 

--- a/pop_tools/region_masks.py
+++ b/pop_tools/region_masks.py
@@ -5,7 +5,7 @@ import yaml
 
 from .grid import get_grid, grid_defs
 
-region_def_file = importlib.resources.files('pop_tools', 'region_mask_definitions.yaml')
+region_def_file = importlib.resources.files('pop_tools').joinpath('region_mask_definitions.yaml')
 # open defined region masks
 with open(region_def_file) as f:
     all_region_defs = yaml.safe_load(f)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ addopts = --cov=./ --cov-report=xml --verbose
 
 [isort]
 known_first_party=pop_tools
-known_third_party=dask,numba,numpy,pkg_resources,pooch,pytest,setuptools,xarray,xgcm,yaml
+known_third_party=dask,numba,numpy,pooch,pytest,setuptools,xarray,xgcm,yaml
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
Replaces pkg_resources (deprecated and now removed) with importlib.

Closes #179 

This should address the CI failures, but obviously will need a release to get things working again for folks.

Happy to clean up the commit history if you're not squashing it - just let me know.